### PR TITLE
joda-time-jsptags:1.0.2 doesn't have a POM in Maven Central, so Maven 3 won't build it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
 		<dependency>
 			<groupId>joda-time</groupId>
 			<artifactId>joda-time-jsptags</artifactId>
-			<version>1.0.2</version>
+			<version>1.1.1</version>
 			<scope>runtime</scope>
 		</dependency>
 


### PR DESCRIPTION
Minor change to POM so recent versions of Maven can build it from an empty local Maven repo.
